### PR TITLE
Fixes flame arrows being able to replace any block with fire

### DIFF
--- a/src/main/java/io/github/strikerrocker/vt/events/EntityEvents.java
+++ b/src/main/java/io/github/strikerrocker/vt/events/EntityEvents.java
@@ -221,7 +221,7 @@ public class EntityEvents {
             Vec3d vec3d1 = new Vec3d(event.getArrow().posX, event.getArrow().posY, event.getArrow().posZ);
             Vec3d vec3d = new Vec3d(event.getArrow().posX + event.getArrow().motionX, event.getArrow().posY + event.getArrow().motionY, event.getArrow().posZ + event.getArrow().motionZ);
             RayTraceResult raytraceresult = event.getArrow().world.rayTraceBlocks(vec3d1, vec3d, false, true, false);
-            if (raytraceresult != null && raytraceresult.typeOfHit == RayTraceResult.Type.BLOCK) {
+            if (raytraceresult != null && raytraceresult.typeOfHit == RayTraceResult.Type.BLOCK && event.getArrow().world.isAirBlock(raytraceresult.getBlockPos().up())) {
                 event.getArrow().world.setBlockState(raytraceresult.getBlockPos().up(), Blocks.FIRE.getDefaultState(), 11);
             }
         }


### PR DESCRIPTION
Fixes flame arrows being able to replace blocks with fire, thus erasing them.

Reproduceable by hitting the side of a block with a flame arrow. Any block on top will be replaced.