### PR TITLE
Fix books being tradeable when disabled

### DIFF
--- a/src/main/java/io/github/strikerrocker/vt/enchantments/BlazingEnchantment.java
+++ b/src/main/java/io/github/strikerrocker/vt/enchantments/BlazingEnchantment.java
@@ -46,4 +46,9 @@ public class BlazingEnchantment extends Enchantment {
     public boolean isTreasureOnly() {
         return EnchantmentInit.blazingTreasureOnly.get();
     }
+
+    @Override
+    public boolean isTradeable() {
+        return EnchantmentInit.enableBlazing.get();
+    }
 }

--- a/src/main/java/io/github/strikerrocker/vt/enchantments/HomingEnchantment.java
+++ b/src/main/java/io/github/strikerrocker/vt/enchantments/HomingEnchantment.java
@@ -116,4 +116,9 @@ public class HomingEnchantment extends Enchantment {
     public boolean isTreasureOnly() {
         return EnchantmentInit.homingTreasureOnly.get();
     }
+
+    @Override
+    public boolean isTradeable() {
+        return EnchantmentInit.enableHoming.get();
+    }
 }

--- a/src/main/java/io/github/strikerrocker/vt/enchantments/HopsEnchantment.java
+++ b/src/main/java/io/github/strikerrocker/vt/enchantments/HopsEnchantment.java
@@ -71,4 +71,9 @@ public class HopsEnchantment extends Enchantment {
     public boolean isTreasureOnly() {
         return EnchantmentInit.hopsTreasureOnly.get();
     }
+
+    @Override
+    public boolean isTradeable() {
+        return EnchantmentInit.enableHops.get();
+    }
 }

--- a/src/main/java/io/github/strikerrocker/vt/enchantments/NimbleEnchantment.java
+++ b/src/main/java/io/github/strikerrocker/vt/enchantments/NimbleEnchantment.java
@@ -79,4 +79,9 @@ public class NimbleEnchantment extends Enchantment {
     public boolean isTreasureOnly() {
         return EnchantmentInit.nimbleTreasureOnly.get();
     }
+
+    @Override
+    public boolean isTradeable() {
+        return EnchantmentInit.enableNimble.get();
+    }
 }

--- a/src/main/java/io/github/strikerrocker/vt/enchantments/SiphonEnchantment.java
+++ b/src/main/java/io/github/strikerrocker/vt/enchantments/SiphonEnchantment.java
@@ -40,4 +40,9 @@ public class SiphonEnchantment extends Enchantment {
     public boolean isTreasureOnly() {
         return EnchantmentInit.siphonTreasureOnly.get();
     }
+
+    @Override
+    public boolean isTradeable() {
+        return EnchantmentInit.enableSiphon.get();
+    }
 }

--- a/src/main/java/io/github/strikerrocker/vt/enchantments/VeteranEnchantment.java
+++ b/src/main/java/io/github/strikerrocker/vt/enchantments/VeteranEnchantment.java
@@ -84,4 +84,9 @@ public class VeteranEnchantment extends Enchantment {
     public boolean isTreasureOnly() {
         return EnchantmentInit.veteranTreasureOnly.get();
     }
+
+    @Override
+    public boolean isTradeable() {
+        return EnchantmentInit.enableVeteran.get();
+    }
 }

--- a/src/main/java/io/github/strikerrocker/vt/enchantments/VigorEnchantment.java
+++ b/src/main/java/io/github/strikerrocker/vt/enchantments/VigorEnchantment.java
@@ -80,4 +80,9 @@ public class VigorEnchantment extends Enchantment {
     public boolean isTreasureOnly() {
         return EnchantmentInit.vigorTreasureOnly.get();
     }
+
+    @Override
+    public boolean isTradeable() {
+        return EnchantmentInit.enableVigor.get();
+    }
 }


### PR DESCRIPTION
fixes #147 

added isTradeable override to return config value.
this will prevent books from being tradeable with disabled enchantments.