### PR TITLE
Check Curse of Binding before removing off Armor Stand

### DIFF
--- a/common/src/main/java/io/github/strikerrocker/vt/tweaks/TweaksImpl.java
+++ b/common/src/main/java/io/github/strikerrocker/vt/tweaks/TweaksImpl.java
@@ -37,8 +37,11 @@ public class TweaksImpl {
     public static void swapSlot(Player player, ArmorStand armorStand, EquipmentSlot slot) {
         ItemStack playerItem = player.getItemBySlot(slot);
         ItemStack armorStandItem = armorStand.getItemBySlot(slot);
-        player.setItemSlot(slot, armorStandItem);
-        armorStand.setItemSlot(slot, playerItem);
+
+        if (player.isCreative() || (!EnchantmentHelper.hasBindingCurse(playerItem) && !EnchantmentHelper.hasBindingCurse(armorStandItem))) {
+            player.setItemSlot(slot, armorStandItem);
+            armorStand.setItemSlot(slot, playerItem);
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #197 

Checks the armor on the player and armor stand to see if the armor can be swapped first. A negative constraint is placed on the curse of binding, but creative mode players override this requirement.

As the behavior of the curse of binding on an armor stand is not defined, an issue has been created on [Mojang's tracker](https://bugs.mojang.com/browse/MC-265638).