### PR TITLE
Prevent ClassCastException in triggerSickle of TweaksImpl.java

### DIFF
--- a/common/src/main/java/io/github/strikerrocker/vt/tweaks/TweaksImpl.java
+++ b/common/src/main/java/io/github/strikerrocker/vt/tweaks/TweaksImpl.java
@@ -1,5 +1,6 @@
 package io.github.strikerrocker.vt.tweaks;
 
+import io.github.strikerrocker.vt.VanillaTweaks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -102,12 +103,21 @@ public class TweaksImpl {
                         continue;
                     BlockPos pos = blockPos.offset(i, 0, k);
                     BlockState state = world.getBlockState(pos);
+                    Block block = state.getBlock();
                     if (TweaksImpl.canHarvest(state)) {
-                        Block block = state.getBlock();
-                        if (player.hasCorrectToolForDrops(state))
-                            block.playerDestroy(world, player, pos, state, world.getBlockEntity(pos), stack);
-                        world.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
-                        world.playSound(player, player.blockPosition(), block.getSoundType(state).getBreakSound(), SoundSource.BLOCKS, 1f, 1f);
+                        // Preventing an ClassCastException here. Not the best solution but it prevents the game from
+                        // outright crashing.
+                        try {
+                            if (player.hasCorrectToolForDrops(state))
+                                block.playerDestroy(world, player, pos, state, world.getBlockEntity(pos), stack);
+                            world.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
+                            world.playSound(player, player.blockPosition(), block.getSoundType(state).getBreakSound(), SoundSource.BLOCKS, 1f, 1f);
+                        } catch (Exception exception) {
+                            VanillaTweaks.LOGGER.warn("{} suppressed whilst triggering sickle ({} @ {})",
+                                    exception.getClass().getSimpleName(),
+                                    block.getName(),
+                                    pos.getX() + ", " + pos.getY() + ", " + pos.getZ());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This PR fixes an issue that me and a few others noticed on our server using VanillaTweaks. An unhandled `ClassCastException` would be raised when trying to harvest crops using a sickle, which would crash the game immediately. Most prominent instance of this was simply trying to break grass with a sickle.

Instead of crashing the game, here I'm suppressing the exception and writing a warning to the logs that looks something like this:
```
[00:28:23] [Render thread/WARN]: ClassCastException suppressed whilst triggering sickle (translation{key='block.minecraft.grass', args=[]} @ 1067, 67, -1335)
```

If you've got a better method of fixing this issue feel free to let me know in review, otherwise this is tested working.

It should also be noted that this fix doesn't stop the crops from being harvested. Everything still works as intended.

I'm also making this change into the 1.20 branch because that's the server version in which the bug took place. You could probably merge the changes up into the 1.20.2 branch.